### PR TITLE
Change Icon type to be React Functional Component

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -17,14 +17,14 @@ if (!fs.existsSync(dir)) {
 }
 
 const initialTypeDefinitions = `/// <reference types="react" />
-import { ComponentType, SVGAttributes } from 'react';
+import { FC, SVGAttributes } from 'react';
 
 interface Props extends SVGAttributes<SVGElement> {
   color?: string;
   size?: string | number;
 }
 
-type Icon = ComponentType<Props>;
+type Icon = FC<Props>;
 `;
 
 fs.writeFileSync(path.join(rootDir, 'src', 'index.js'), '', 'utf-8');

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,12 +1,12 @@
 /// <reference types="react" />
-import { ComponentType, SVGAttributes } from 'react';
+import { FC, SVGAttributes } from 'react';
 
 interface Props extends SVGAttributes<SVGElement> {
   color?: string;
   size?: string | number;
 }
 
-type Icon = ComponentType<Props>;
+type Icon = FC<Props>;
 export const Activity: Icon;
 export const Airplay: Icon;
 export const AlertCircle: Icon;


### PR DESCRIPTION
With the most recent release of @types/styled-components, TypeScript errored out unable to instantiate types due to "Type instantiation is excessively deep and possibly infinite."

I looked at the source code of `react-feather`, and seems like all components are functional components, even though the TypeScript type marks them as `React.ComponentType` which is a union of functional and class component. Manually casting my imports from `react-feather` to `React.FC<React.ComponentProps<Icon>>` solves this problem because TypeScript does not have to go down the path of class components.

I decided that in the long run, the most appropriate fix would be upstream in the type definition itself