### PR TITLE
Change default size to 1em

### DIFF
--- a/src/icons/activity.js
+++ b/src/icons/activity.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Activity = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Activity = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/airplay.js
+++ b/src/icons/airplay.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Airplay = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Airplay = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/alert-circle.js
+++ b/src/icons/alert-circle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const AlertCircle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const AlertCircle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/alert-octagon.js
+++ b/src/icons/alert-octagon.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const AlertOctagon = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const AlertOctagon = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/alert-triangle.js
+++ b/src/icons/alert-triangle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const AlertTriangle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const AlertTriangle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/align-center.js
+++ b/src/icons/align-center.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const AlignCenter = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const AlignCenter = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/align-justify.js
+++ b/src/icons/align-justify.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const AlignJustify = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const AlignJustify = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/align-left.js
+++ b/src/icons/align-left.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const AlignLeft = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const AlignLeft = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/align-right.js
+++ b/src/icons/align-right.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const AlignRight = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const AlignRight = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/anchor.js
+++ b/src/icons/anchor.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Anchor = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Anchor = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/aperture.js
+++ b/src/icons/aperture.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Aperture = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Aperture = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/archive.js
+++ b/src/icons/archive.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Archive = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Archive = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/arrow-down-circle.js
+++ b/src/icons/arrow-down-circle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ArrowDownCircle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ArrowDownCircle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/arrow-down-left.js
+++ b/src/icons/arrow-down-left.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ArrowDownLeft = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ArrowDownLeft = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/arrow-down-right.js
+++ b/src/icons/arrow-down-right.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ArrowDownRight = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ArrowDownRight = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/arrow-down.js
+++ b/src/icons/arrow-down.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ArrowDown = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ArrowDown = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/arrow-left-circle.js
+++ b/src/icons/arrow-left-circle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ArrowLeftCircle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ArrowLeftCircle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/arrow-left.js
+++ b/src/icons/arrow-left.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ArrowLeft = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ArrowLeft = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/arrow-right-circle.js
+++ b/src/icons/arrow-right-circle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ArrowRightCircle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ArrowRightCircle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/arrow-right.js
+++ b/src/icons/arrow-right.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ArrowRight = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ArrowRight = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/arrow-up-circle.js
+++ b/src/icons/arrow-up-circle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ArrowUpCircle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ArrowUpCircle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/arrow-up-left.js
+++ b/src/icons/arrow-up-left.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ArrowUpLeft = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ArrowUpLeft = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/arrow-up-right.js
+++ b/src/icons/arrow-up-right.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ArrowUpRight = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ArrowUpRight = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/arrow-up.js
+++ b/src/icons/arrow-up.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ArrowUp = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ArrowUp = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/at-sign.js
+++ b/src/icons/at-sign.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const AtSign = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const AtSign = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/award.js
+++ b/src/icons/award.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Award = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Award = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/bar-chart-2.js
+++ b/src/icons/bar-chart-2.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const BarChart2 = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const BarChart2 = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/bar-chart.js
+++ b/src/icons/bar-chart.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const BarChart = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const BarChart = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/battery-charging.js
+++ b/src/icons/battery-charging.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const BatteryCharging = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const BatteryCharging = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/battery.js
+++ b/src/icons/battery.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Battery = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Battery = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/bell-off.js
+++ b/src/icons/bell-off.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const BellOff = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const BellOff = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/bell.js
+++ b/src/icons/bell.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Bell = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Bell = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/bluetooth.js
+++ b/src/icons/bluetooth.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Bluetooth = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Bluetooth = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/bold.js
+++ b/src/icons/bold.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Bold = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Bold = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/book-open.js
+++ b/src/icons/book-open.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const BookOpen = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const BookOpen = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/book.js
+++ b/src/icons/book.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Book = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Book = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/bookmark.js
+++ b/src/icons/bookmark.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Bookmark = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Bookmark = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/box.js
+++ b/src/icons/box.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Box = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Box = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/briefcase.js
+++ b/src/icons/briefcase.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Briefcase = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Briefcase = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/calendar.js
+++ b/src/icons/calendar.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Calendar = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Calendar = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/camera-off.js
+++ b/src/icons/camera-off.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CameraOff = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CameraOff = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/camera.js
+++ b/src/icons/camera.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Camera = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Camera = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/cast.js
+++ b/src/icons/cast.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Cast = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Cast = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/check-circle.js
+++ b/src/icons/check-circle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CheckCircle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CheckCircle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/check-square.js
+++ b/src/icons/check-square.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CheckSquare = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CheckSquare = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/check.js
+++ b/src/icons/check.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Check = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Check = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/chevron-down.js
+++ b/src/icons/chevron-down.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ChevronDown = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ChevronDown = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/chevron-left.js
+++ b/src/icons/chevron-left.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ChevronLeft = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ChevronLeft = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/chevron-right.js
+++ b/src/icons/chevron-right.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ChevronRight = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ChevronRight = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/chevron-up.js
+++ b/src/icons/chevron-up.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ChevronUp = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ChevronUp = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/chevrons-down.js
+++ b/src/icons/chevrons-down.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ChevronsDown = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ChevronsDown = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/chevrons-left.js
+++ b/src/icons/chevrons-left.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ChevronsLeft = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ChevronsLeft = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/chevrons-right.js
+++ b/src/icons/chevrons-right.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ChevronsRight = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ChevronsRight = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/chevrons-up.js
+++ b/src/icons/chevrons-up.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ChevronsUp = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ChevronsUp = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/chrome.js
+++ b/src/icons/chrome.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Chrome = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Chrome = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/circle.js
+++ b/src/icons/circle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Circle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Circle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/clipboard.js
+++ b/src/icons/clipboard.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Clipboard = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Clipboard = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/clock.js
+++ b/src/icons/clock.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Clock = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Clock = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/cloud-drizzle.js
+++ b/src/icons/cloud-drizzle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CloudDrizzle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CloudDrizzle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/cloud-lightning.js
+++ b/src/icons/cloud-lightning.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CloudLightning = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CloudLightning = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/cloud-off.js
+++ b/src/icons/cloud-off.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CloudOff = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CloudOff = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/cloud-rain.js
+++ b/src/icons/cloud-rain.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CloudRain = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CloudRain = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/cloud-snow.js
+++ b/src/icons/cloud-snow.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CloudSnow = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CloudSnow = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/cloud.js
+++ b/src/icons/cloud.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Cloud = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Cloud = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/code.js
+++ b/src/icons/code.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Code = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Code = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/codepen.js
+++ b/src/icons/codepen.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Codepen = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Codepen = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/codesandbox.js
+++ b/src/icons/codesandbox.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Codesandbox = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Codesandbox = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/coffee.js
+++ b/src/icons/coffee.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Coffee = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Coffee = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/columns.js
+++ b/src/icons/columns.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Columns = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Columns = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/command.js
+++ b/src/icons/command.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Command = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Command = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/compass.js
+++ b/src/icons/compass.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Compass = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Compass = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/copy.js
+++ b/src/icons/copy.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Copy = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Copy = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/corner-down-left.js
+++ b/src/icons/corner-down-left.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CornerDownLeft = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CornerDownLeft = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/corner-down-right.js
+++ b/src/icons/corner-down-right.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CornerDownRight = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CornerDownRight = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/corner-left-down.js
+++ b/src/icons/corner-left-down.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CornerLeftDown = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CornerLeftDown = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/corner-left-up.js
+++ b/src/icons/corner-left-up.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CornerLeftUp = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CornerLeftUp = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/corner-right-down.js
+++ b/src/icons/corner-right-down.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CornerRightDown = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CornerRightDown = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/corner-right-up.js
+++ b/src/icons/corner-right-up.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CornerRightUp = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CornerRightUp = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/corner-up-left.js
+++ b/src/icons/corner-up-left.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CornerUpLeft = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CornerUpLeft = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/corner-up-right.js
+++ b/src/icons/corner-up-right.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CornerUpRight = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CornerUpRight = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/cpu.js
+++ b/src/icons/cpu.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Cpu = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Cpu = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/credit-card.js
+++ b/src/icons/credit-card.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const CreditCard = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const CreditCard = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/crop.js
+++ b/src/icons/crop.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Crop = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Crop = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/crosshair.js
+++ b/src/icons/crosshair.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Crosshair = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Crosshair = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/database.js
+++ b/src/icons/database.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Database = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Database = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/delete.js
+++ b/src/icons/delete.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Delete = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Delete = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/disc.js
+++ b/src/icons/disc.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Disc = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Disc = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/divide-circle.js
+++ b/src/icons/divide-circle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const DivideCircle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const DivideCircle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/divide-square.js
+++ b/src/icons/divide-square.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const DivideSquare = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const DivideSquare = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/divide.js
+++ b/src/icons/divide.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Divide = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Divide = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/dollar-sign.js
+++ b/src/icons/dollar-sign.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const DollarSign = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const DollarSign = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/download-cloud.js
+++ b/src/icons/download-cloud.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const DownloadCloud = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const DownloadCloud = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/download.js
+++ b/src/icons/download.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Download = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Download = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/dribbble.js
+++ b/src/icons/dribbble.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Dribbble = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Dribbble = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/droplet.js
+++ b/src/icons/droplet.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Droplet = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Droplet = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/edit-2.js
+++ b/src/icons/edit-2.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Edit2 = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Edit2 = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/edit-3.js
+++ b/src/icons/edit-3.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Edit3 = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Edit3 = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/edit.js
+++ b/src/icons/edit.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Edit = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Edit = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/external-link.js
+++ b/src/icons/external-link.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ExternalLink = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ExternalLink = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/eye-off.js
+++ b/src/icons/eye-off.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const EyeOff = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const EyeOff = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/eye.js
+++ b/src/icons/eye.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Eye = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Eye = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/facebook.js
+++ b/src/icons/facebook.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Facebook = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Facebook = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/fast-forward.js
+++ b/src/icons/fast-forward.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const FastForward = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const FastForward = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/feather.js
+++ b/src/icons/feather.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Feather = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Feather = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/figma.js
+++ b/src/icons/figma.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Figma = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Figma = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/file-minus.js
+++ b/src/icons/file-minus.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const FileMinus = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const FileMinus = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/file-plus.js
+++ b/src/icons/file-plus.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const FilePlus = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const FilePlus = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/file-text.js
+++ b/src/icons/file-text.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const FileText = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const FileText = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/file.js
+++ b/src/icons/file.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const File = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const File = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/film.js
+++ b/src/icons/film.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Film = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Film = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/filter.js
+++ b/src/icons/filter.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Filter = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Filter = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/flag.js
+++ b/src/icons/flag.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Flag = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Flag = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/folder-minus.js
+++ b/src/icons/folder-minus.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const FolderMinus = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const FolderMinus = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/folder-plus.js
+++ b/src/icons/folder-plus.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const FolderPlus = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const FolderPlus = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/folder.js
+++ b/src/icons/folder.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Folder = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Folder = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/framer.js
+++ b/src/icons/framer.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Framer = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Framer = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/frown.js
+++ b/src/icons/frown.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Frown = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Frown = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/gift.js
+++ b/src/icons/gift.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Gift = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Gift = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/git-branch.js
+++ b/src/icons/git-branch.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const GitBranch = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const GitBranch = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/git-commit.js
+++ b/src/icons/git-commit.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const GitCommit = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const GitCommit = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/git-merge.js
+++ b/src/icons/git-merge.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const GitMerge = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const GitMerge = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/git-pull-request.js
+++ b/src/icons/git-pull-request.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const GitPullRequest = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const GitPullRequest = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/github.js
+++ b/src/icons/github.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const GitHub = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const GitHub = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/gitlab.js
+++ b/src/icons/gitlab.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Gitlab = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Gitlab = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/globe.js
+++ b/src/icons/globe.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Globe = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Globe = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/grid.js
+++ b/src/icons/grid.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Grid = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Grid = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/hard-drive.js
+++ b/src/icons/hard-drive.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const HardDrive = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const HardDrive = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/hash.js
+++ b/src/icons/hash.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Hash = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Hash = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/headphones.js
+++ b/src/icons/headphones.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Headphones = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Headphones = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/heart.js
+++ b/src/icons/heart.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Heart = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Heart = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/help-circle.js
+++ b/src/icons/help-circle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const HelpCircle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const HelpCircle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/hexagon.js
+++ b/src/icons/hexagon.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Hexagon = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Hexagon = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/home.js
+++ b/src/icons/home.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Home = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Home = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/image.js
+++ b/src/icons/image.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Image = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Image = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/inbox.js
+++ b/src/icons/inbox.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Inbox = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Inbox = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/info.js
+++ b/src/icons/info.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Info = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Info = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/instagram.js
+++ b/src/icons/instagram.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Instagram = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Instagram = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/italic.js
+++ b/src/icons/italic.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Italic = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Italic = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/key.js
+++ b/src/icons/key.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Key = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Key = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/layers.js
+++ b/src/icons/layers.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Layers = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Layers = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/layout.js
+++ b/src/icons/layout.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Layout = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Layout = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/life-buoy.js
+++ b/src/icons/life-buoy.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const LifeBuoy = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const LifeBuoy = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/link-2.js
+++ b/src/icons/link-2.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Link2 = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Link2 = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/link.js
+++ b/src/icons/link.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Link = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Link = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/linkedin.js
+++ b/src/icons/linkedin.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Linkedin = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Linkedin = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/list.js
+++ b/src/icons/list.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const List = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const List = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/loader.js
+++ b/src/icons/loader.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Loader = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Loader = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/lock.js
+++ b/src/icons/lock.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Lock = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Lock = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/log-in.js
+++ b/src/icons/log-in.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const LogIn = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const LogIn = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/log-out.js
+++ b/src/icons/log-out.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const LogOut = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const LogOut = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/mail.js
+++ b/src/icons/mail.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Mail = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Mail = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/map-pin.js
+++ b/src/icons/map-pin.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const MapPin = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const MapPin = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/map.js
+++ b/src/icons/map.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Map = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Map = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/maximize-2.js
+++ b/src/icons/maximize-2.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Maximize2 = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Maximize2 = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/maximize.js
+++ b/src/icons/maximize.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Maximize = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Maximize = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/meh.js
+++ b/src/icons/meh.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Meh = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Meh = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/menu.js
+++ b/src/icons/menu.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Menu = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Menu = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/message-circle.js
+++ b/src/icons/message-circle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const MessageCircle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const MessageCircle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/message-square.js
+++ b/src/icons/message-square.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const MessageSquare = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const MessageSquare = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/mic-off.js
+++ b/src/icons/mic-off.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const MicOff = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const MicOff = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/mic.js
+++ b/src/icons/mic.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Mic = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Mic = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/minimize-2.js
+++ b/src/icons/minimize-2.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Minimize2 = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Minimize2 = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/minimize.js
+++ b/src/icons/minimize.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Minimize = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Minimize = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/minus-circle.js
+++ b/src/icons/minus-circle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const MinusCircle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const MinusCircle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/minus-square.js
+++ b/src/icons/minus-square.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const MinusSquare = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const MinusSquare = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/minus.js
+++ b/src/icons/minus.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Minus = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Minus = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/monitor.js
+++ b/src/icons/monitor.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Monitor = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Monitor = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/moon.js
+++ b/src/icons/moon.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Moon = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Moon = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/more-horizontal.js
+++ b/src/icons/more-horizontal.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const MoreHorizontal = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const MoreHorizontal = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/more-vertical.js
+++ b/src/icons/more-vertical.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const MoreVertical = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const MoreVertical = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/mouse-pointer.js
+++ b/src/icons/mouse-pointer.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const MousePointer = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const MousePointer = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/move.js
+++ b/src/icons/move.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Move = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Move = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/music.js
+++ b/src/icons/music.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Music = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Music = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/navigation-2.js
+++ b/src/icons/navigation-2.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Navigation2 = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Navigation2 = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/navigation.js
+++ b/src/icons/navigation.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Navigation = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Navigation = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/octagon.js
+++ b/src/icons/octagon.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Octagon = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Octagon = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/package.js
+++ b/src/icons/package.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Package = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Package = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/paperclip.js
+++ b/src/icons/paperclip.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Paperclip = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Paperclip = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/pause-circle.js
+++ b/src/icons/pause-circle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const PauseCircle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const PauseCircle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/pause.js
+++ b/src/icons/pause.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Pause = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Pause = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/pen-tool.js
+++ b/src/icons/pen-tool.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const PenTool = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const PenTool = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/percent.js
+++ b/src/icons/percent.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Percent = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Percent = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/phone-call.js
+++ b/src/icons/phone-call.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const PhoneCall = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const PhoneCall = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/phone-forwarded.js
+++ b/src/icons/phone-forwarded.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const PhoneForwarded = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const PhoneForwarded = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/phone-incoming.js
+++ b/src/icons/phone-incoming.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const PhoneIncoming = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const PhoneIncoming = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/phone-missed.js
+++ b/src/icons/phone-missed.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const PhoneMissed = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const PhoneMissed = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/phone-off.js
+++ b/src/icons/phone-off.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const PhoneOff = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const PhoneOff = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/phone-outgoing.js
+++ b/src/icons/phone-outgoing.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const PhoneOutgoing = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const PhoneOutgoing = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/phone.js
+++ b/src/icons/phone.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Phone = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Phone = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/pie-chart.js
+++ b/src/icons/pie-chart.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const PieChart = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const PieChart = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/play-circle.js
+++ b/src/icons/play-circle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const PlayCircle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const PlayCircle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/play.js
+++ b/src/icons/play.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Play = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Play = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/plus-circle.js
+++ b/src/icons/plus-circle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const PlusCircle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const PlusCircle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/plus-square.js
+++ b/src/icons/plus-square.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const PlusSquare = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const PlusSquare = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/plus.js
+++ b/src/icons/plus.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Plus = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Plus = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/pocket.js
+++ b/src/icons/pocket.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Pocket = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Pocket = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/power.js
+++ b/src/icons/power.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Power = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Power = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/printer.js
+++ b/src/icons/printer.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Printer = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Printer = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/radio.js
+++ b/src/icons/radio.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Radio = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Radio = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/refresh-ccw.js
+++ b/src/icons/refresh-ccw.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const RefreshCcw = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const RefreshCcw = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/refresh-cw.js
+++ b/src/icons/refresh-cw.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const RefreshCw = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const RefreshCw = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/repeat.js
+++ b/src/icons/repeat.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Repeat = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Repeat = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/rewind.js
+++ b/src/icons/rewind.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Rewind = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Rewind = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/rotate-ccw.js
+++ b/src/icons/rotate-ccw.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const RotateCcw = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const RotateCcw = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/rotate-cw.js
+++ b/src/icons/rotate-cw.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const RotateCw = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const RotateCw = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/rss.js
+++ b/src/icons/rss.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Rss = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Rss = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/save.js
+++ b/src/icons/save.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Save = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Save = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/scissors.js
+++ b/src/icons/scissors.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Scissors = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Scissors = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/search.js
+++ b/src/icons/search.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Search = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Search = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/send.js
+++ b/src/icons/send.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Send = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Send = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/server.js
+++ b/src/icons/server.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Server = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Server = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/settings.js
+++ b/src/icons/settings.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Settings = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Settings = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/share-2.js
+++ b/src/icons/share-2.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Share2 = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Share2 = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/share.js
+++ b/src/icons/share.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Share = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Share = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/shield-off.js
+++ b/src/icons/shield-off.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ShieldOff = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ShieldOff = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/shield.js
+++ b/src/icons/shield.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Shield = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Shield = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/shopping-bag.js
+++ b/src/icons/shopping-bag.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ShoppingBag = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ShoppingBag = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/shopping-cart.js
+++ b/src/icons/shopping-cart.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ShoppingCart = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ShoppingCart = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/shuffle.js
+++ b/src/icons/shuffle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Shuffle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Shuffle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/sidebar.js
+++ b/src/icons/sidebar.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Sidebar = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Sidebar = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/skip-back.js
+++ b/src/icons/skip-back.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const SkipBack = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const SkipBack = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/skip-forward.js
+++ b/src/icons/skip-forward.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const SkipForward = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const SkipForward = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/slack.js
+++ b/src/icons/slack.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Slack = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Slack = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/slash.js
+++ b/src/icons/slash.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Slash = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Slash = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/sliders.js
+++ b/src/icons/sliders.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Sliders = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Sliders = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/smartphone.js
+++ b/src/icons/smartphone.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Smartphone = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Smartphone = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/smile.js
+++ b/src/icons/smile.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Smile = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Smile = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/speaker.js
+++ b/src/icons/speaker.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Speaker = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Speaker = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/square.js
+++ b/src/icons/square.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Square = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Square = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/star.js
+++ b/src/icons/star.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Star = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Star = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/stop-circle.js
+++ b/src/icons/stop-circle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const StopCircle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const StopCircle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/sun.js
+++ b/src/icons/sun.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Sun = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Sun = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/sunrise.js
+++ b/src/icons/sunrise.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Sunrise = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Sunrise = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/sunset.js
+++ b/src/icons/sunset.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Sunset = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Sunset = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/tablet.js
+++ b/src/icons/tablet.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Tablet = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Tablet = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/tag.js
+++ b/src/icons/tag.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Tag = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Tag = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/target.js
+++ b/src/icons/target.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Target = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Target = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/terminal.js
+++ b/src/icons/terminal.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Terminal = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Terminal = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/thermometer.js
+++ b/src/icons/thermometer.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Thermometer = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Thermometer = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/thumbs-down.js
+++ b/src/icons/thumbs-down.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ThumbsDown = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ThumbsDown = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/thumbs-up.js
+++ b/src/icons/thumbs-up.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ThumbsUp = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ThumbsUp = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/toggle-left.js
+++ b/src/icons/toggle-left.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ToggleLeft = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ToggleLeft = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/toggle-right.js
+++ b/src/icons/toggle-right.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ToggleRight = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ToggleRight = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/tool.js
+++ b/src/icons/tool.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Tool = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Tool = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/trash-2.js
+++ b/src/icons/trash-2.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Trash2 = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Trash2 = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/trash.js
+++ b/src/icons/trash.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Trash = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Trash = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/trello.js
+++ b/src/icons/trello.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Trello = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Trello = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/trending-down.js
+++ b/src/icons/trending-down.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const TrendingDown = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const TrendingDown = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/trending-up.js
+++ b/src/icons/trending-up.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const TrendingUp = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const TrendingUp = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/triangle.js
+++ b/src/icons/triangle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Triangle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Triangle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/truck.js
+++ b/src/icons/truck.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Truck = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Truck = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/tv.js
+++ b/src/icons/tv.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Tv = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Tv = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/twitch.js
+++ b/src/icons/twitch.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Twitch = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Twitch = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/twitter.js
+++ b/src/icons/twitter.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Twitter = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Twitter = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/type.js
+++ b/src/icons/type.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Type = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Type = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/umbrella.js
+++ b/src/icons/umbrella.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Umbrella = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Umbrella = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/underline.js
+++ b/src/icons/underline.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Underline = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Underline = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/unlock.js
+++ b/src/icons/unlock.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Unlock = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Unlock = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/upload-cloud.js
+++ b/src/icons/upload-cloud.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const UploadCloud = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const UploadCloud = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/upload.js
+++ b/src/icons/upload.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Upload = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Upload = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/user-check.js
+++ b/src/icons/user-check.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const UserCheck = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const UserCheck = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/user-minus.js
+++ b/src/icons/user-minus.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const UserMinus = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const UserMinus = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/user-plus.js
+++ b/src/icons/user-plus.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const UserPlus = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const UserPlus = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/user-x.js
+++ b/src/icons/user-x.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const UserX = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const UserX = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/user.js
+++ b/src/icons/user.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const User = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const User = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/users.js
+++ b/src/icons/users.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Users = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Users = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/video-off.js
+++ b/src/icons/video-off.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const VideoOff = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const VideoOff = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/video.js
+++ b/src/icons/video.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Video = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Video = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/voicemail.js
+++ b/src/icons/voicemail.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Voicemail = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Voicemail = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/volume-1.js
+++ b/src/icons/volume-1.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Volume1 = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Volume1 = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/volume-2.js
+++ b/src/icons/volume-2.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Volume2 = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Volume2 = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/volume-x.js
+++ b/src/icons/volume-x.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const VolumeX = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const VolumeX = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/volume.js
+++ b/src/icons/volume.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Volume = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Volume = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/watch.js
+++ b/src/icons/watch.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Watch = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Watch = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/wifi-off.js
+++ b/src/icons/wifi-off.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const WifiOff = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const WifiOff = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/wifi.js
+++ b/src/icons/wifi.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Wifi = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Wifi = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/wind.js
+++ b/src/icons/wind.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Wind = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Wind = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/x-circle.js
+++ b/src/icons/x-circle.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const XCircle = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const XCircle = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/x-octagon.js
+++ b/src/icons/x-octagon.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const XOctagon = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const XOctagon = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/x-square.js
+++ b/src/icons/x-square.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const XSquare = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const XSquare = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/x.js
+++ b/src/icons/x.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const X = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const X = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/youtube.js
+++ b/src/icons/youtube.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Youtube = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Youtube = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/zap-off.js
+++ b/src/icons/zap-off.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ZapOff = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ZapOff = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/zap.js
+++ b/src/icons/zap.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Zap = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const Zap = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/zoom-in.js
+++ b/src/icons/zoom-in.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ZoomIn = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ZoomIn = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}

--- a/src/icons/zoom-out.js
+++ b/src/icons/zoom-out.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
-const ZoomOut = forwardRef(({ color = 'currentColor', size = 24, ...rest }, ref) => {
+const ZoomOut = forwardRef(({ color = 'currentColor', size = "1em", ...rest }, ref) => {
   return (
     <svg
       ref={ref}


### PR DESCRIPTION
According to #40, I think a better way to adapt the sizes would be to define by default with typographic measures, instead of pixels.

### Changes

- Changed props default value from "24px" to "1em"