### PR TITLE
Export IconProps typedef so projects can re-use

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,12 +1,12 @@
 /// <reference types="react" />
 import { FC, SVGAttributes } from 'react';
 
-interface Props extends SVGAttributes<SVGElement> {
+export interface IconProps extends SVGAttributes<SVGElement> {
   color?: string;
   size?: string | number;
 }
 
-type Icon = FC<Props>;
+type Icon = FC<IconProps>;
 export const Activity: Icon;
 export const Airplay: Icon;
 export const AlertCircle: Icon;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,7 @@ export interface IconProps extends SVGAttributes<SVGElement> {
   size?: string | number;
 }
 
-type Icon = FC<IconProps>;
+export type Icon = FC<IconProps>;
 export const Activity: Icon;
 export const Airplay: Icon;
 export const AlertCircle: Icon;


### PR DESCRIPTION
# What this is
- This exports the IconProps interface and Icon type, so they can be available to TypeScript components using react-feather. As is, it needs to duplicated, which is fragile because react-feather could change their props internally.

- Renamed "Props" to "IconProps" so it is less generic and more obvious to components using it.