### PR TITLE
Support React v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "uppercamelcase": "^3.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || ^17"
+    "react": "^16.8.6 || ^17 || ^18"
   },
   "dependencies": {
     "prop-types": "^15.7.2"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "uppercamelcase": "^3.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || ^17 || ^18"
+    "react": ">=16.8.6"
   },
   "dependencies": {
     "prop-types": "^15.7.2"


### PR DESCRIPTION
React v18 is out: https://reactjs.org/blog/2022/03/29/react-v18.html

React Feather does not have any particular dependencies that gonna fail, but the way how `peerDependencies` are defined makes it harder to upgrade due to NPM warnings.